### PR TITLE
Pom cleanup, nullability annotation migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea
 *.iml
 out
+target
 gen
 
 # Compiled class file

--- a/pom.xml
+++ b/pom.xml
@@ -8,11 +8,14 @@
     <artifactId>ChatMenuAPI</artifactId>
     <version>1.0</version>
 
-    <packaging>jar</packaging>
-
     <name>ChatMenuAPI</name>
     <description>An API for making menus inside Minecraft's chat.</description>
     <url>https://github.com/timtomtim7/ChatMenuAPI</url>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
 
     <licenses>
         <license>
@@ -22,41 +25,24 @@
         </license>
     </licenses>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.12-R0.1-SNAPSHOT</version>
+            <version>1.12.2-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId> <!-- Use 'netty-all' for 4.0 or above -->
             <version>4.0.23.Final</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
-        <!--<dependency>-->
-        <!--<groupId>org.spigotmc</groupId>-->
-        <!--<artifactId>spigot</artifactId>-->
-        <!--<version>1.12-R0.1-SNAPSHOT</version>-->
-        <!--</dependency>-->
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-            <version>3.0.2</version>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>17.0.0</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/me/tom/sparse/spigot/chat/menu/ChatMenu.java
+++ b/src/main/java/me/tom/sparse/spigot/chat/menu/ChatMenu.java
@@ -8,20 +8,20 @@ import me.tom.sparse.spigot.chat.util.Text;
 import net.md_5.bungee.api.chat.BaseComponent;
 import org.bukkit.entity.Player;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.*;
 
 public class ChatMenu implements IElementContainer
 {
-	@Nonnull
+	@NotNull
 	protected final String  id;
 	protected       boolean registered;
 
-	@Nonnull
+	@NotNull
 	protected List<Element> elements;
 
-	@Nonnull
+	@NotNull
 	protected Set<Player> viewers   = new ConcurrentSet<>();
 	protected boolean     pauseChat = false;
 	
@@ -32,7 +32,7 @@ public class ChatMenu implements IElementContainer
 	 *
 	 * @param elements the elements to start the menu with.
 	 */
-	public ChatMenu(@Nonnull Element... elements)
+	public ChatMenu(@NotNull Element... elements)
 	{
 		this(Arrays.asList(elements));
 	}
@@ -42,7 +42,7 @@ public class ChatMenu implements IElementContainer
 	 *
 	 * @param elements the elements to start the menu with.
 	 */
-	public ChatMenu(@Nonnull Collection<Element> elements)
+	public ChatMenu(@NotNull Collection<Element> elements)
 	{
 		this.elements = new ArrayList<>();
 		this.elements.addAll(elements);
@@ -93,7 +93,7 @@ public class ChatMenu implements IElementContainer
 	 * @throws IllegalArgumentException if the element is null
 	 */
 	@Deprecated
-	public void addElement(@Nonnull Element element)
+	public void addElement(@NotNull Element element)
 	{
 		add(element);
 	}
@@ -105,7 +105,7 @@ public class ChatMenu implements IElementContainer
 	 * @param <T> the type of element
 	 * @return the element added
 	 */
-	public <T extends Element> T add(@Nonnull T t)
+	public <T extends Element> T add(@NotNull T t)
 	{
 		Objects.requireNonNull(t);
 		elements.add(t);
@@ -119,7 +119,7 @@ public class ChatMenu implements IElementContainer
 	 * @param element the element to remove
 	 * @return true if the element was removed
 	 */
-	public boolean remove(@Nonnull Element element)
+	public boolean remove(@NotNull Element element)
 	{
 		return elements.remove(element);
 	}
@@ -127,7 +127,7 @@ public class ChatMenu implements IElementContainer
 	/**
 	 * @return an unmodifiable list of all the elements in this menu.
 	 */
-	@Nonnull
+	@NotNull
 	public List<Element> getElements()
 	{
 		return Collections.unmodifiableList(elements);
@@ -140,7 +140,7 @@ public class ChatMenu implements IElementContainer
 	 * @param elementIndex the index of the element that was edited
 	 * @param args         the data to be parsed by the element
 	 */
-	public void edit(@Nonnull Player player, int elementIndex, @Nonnull String[] args)
+	public void edit(@NotNull Player player, int elementIndex, @NotNull String[] args)
 	{
 		if(elementIndex < 0 || elementIndex >= elements.size())
 			return;
@@ -156,7 +156,7 @@ public class ChatMenu implements IElementContainer
 	 *
 	 * @param player the player to send the menu to.
 	 */
-	public void openFor(@Nonnull Player player)
+	public void openFor(@NotNull Player player)
 	{
 		PlayerChatIntercept chat = ChatMenuAPI.getChatIntercept(player);
 		if(viewers.add(player) && pauseChat)
@@ -176,7 +176,7 @@ public class ChatMenu implements IElementContainer
 			openFor(viewer);
 	}
 
-	@Nonnull
+	@NotNull
 	public List<BaseComponent[]> build()
 	{
 		Element overlapping = findOverlap();
@@ -243,7 +243,7 @@ public class ChatMenu implements IElementContainer
 	 *
 	 * @param player the player that closed the menu
 	 */
-	public void close(@Nonnull Player player)
+	public void close(@NotNull Player player)
 	{
 		if(viewers.remove(player))
 		{
@@ -254,7 +254,7 @@ public class ChatMenu implements IElementContainer
 			unregister();
 	}
 	
-	void onClosed(@Nonnull Player player)
+	void onClosed(@NotNull Player player)
 	{
 		if(viewers.remove(player))
 			ChatMenuAPI.getChatIntercept(player).resume();
@@ -263,7 +263,7 @@ public class ChatMenu implements IElementContainer
 	/**
 	 * @return the command used to interact with this menu
 	 */
-	@Nonnull
+	@NotNull
 	public String getCommand()
 	{
 		if(!isRegistered())
@@ -275,8 +275,8 @@ public class ChatMenu implements IElementContainer
 	 * @param element the element to interact with
 	 * @return the command used to interact with the provided element
 	 */
-	@Nonnull
-	public String getCommand(@Nonnull Element element)
+	@NotNull
+	public String getCommand(@NotNull Element element)
 	{
 		return getCommand() + elements.indexOf(element)+" ";
 	}
@@ -302,7 +302,7 @@ public class ChatMenu implements IElementContainer
 	 * Makes this menu pause chat when it is opened
 	 * @return this
 	 */
-	@Nonnull
+	@NotNull
 	public ChatMenu pauseChat()
 	{
 		setPauseChat(true);
@@ -317,8 +317,8 @@ public class ChatMenu implements IElementContainer
 	 * @param text the text of the close button
 	 * @return this
 	 */
-	@Nonnull
-	public ChatMenu pauseChat(int x, int y, @Nonnull String text)
+	@NotNull
+	public ChatMenu pauseChat(int x, int y, @NotNull String text)
 	{
 		setPauseChat(true);
 		add(ButtonElement.createCloseButton(x, y, text, this));

--- a/src/main/java/me/tom/sparse/spigot/chat/menu/ChatMenuAPI.java
+++ b/src/main/java/me/tom/sparse/spigot/chat/menu/ChatMenuAPI.java
@@ -8,8 +8,8 @@ import org.bukkit.map.MapFont;
 import org.bukkit.map.MinecraftFont;
 import org.bukkit.plugin.Plugin;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
@@ -29,7 +29,7 @@ public final class ChatMenuAPI
 	 * @return the menu the player currently has open, or {@code null} if no menu is open.
 	 */
 	@Nullable
-	public static ChatMenu getCurrentMenu(@Nonnull Player player)
+	public static ChatMenu getCurrentMenu(@NotNull Player player)
 	{
 		return OPENED_MENUS.get(player);
 	}
@@ -38,14 +38,14 @@ public final class ChatMenuAPI
 	 * @param player the player whose current menu should be returned
 	 * @param menu   the menu to set as current, or {@code null} if you want to close the current menu.
 	 */
-	public static void setCurrentMenu(@Nonnull Player player, @Nullable ChatMenu menu)
+	public static void setCurrentMenu(@NotNull Player player, @Nullable ChatMenu menu)
 	{
 		ChatMenu old = OPENED_MENUS.remove(player);
 		if(old != null && old != menu) old.onClosed(player);
 		if(menu != null) OPENED_MENUS.put(player, menu);
 	}
 
-	@Nonnull
+	@NotNull
 	static String registerMenu(ChatMenu menu)
 	{
 		String id = generateIdentifier();
@@ -53,12 +53,12 @@ public final class ChatMenuAPI
 		return id;
 	}
 
-	static void unregisterMenu(@Nonnull ChatMenu menu)
+	static void unregisterMenu(@NotNull ChatMenu menu)
 	{
 		MENUS.values().remove(menu);
 	}
 
-	@Nonnull
+	@NotNull
 	private static String generateIdentifier()
 	{
 		String result = null;
@@ -78,8 +78,8 @@ public final class ChatMenuAPI
 	 * @param player the player to get/create the {@link PlayerChatIntercept} for
 	 * @return the {@link PlayerChatIntercept} associated with the provided player
 	 */
-	@Nonnull
-	public static PlayerChatIntercept getChatIntercept(@Nonnull Player player)
+	@NotNull
+	public static PlayerChatIntercept getChatIntercept(@NotNull Player player)
 	{
 		return interceptor.getChat(player);
 	}
@@ -92,7 +92,7 @@ public final class ChatMenuAPI
 	 * @param text the text to calculate the width for
 	 * @return the number of pixels in chat the text takes up
 	 */
-	public static int getWidth(@Nonnull String text)
+	public static int getWidth(@NotNull String text)
 	{
 		if(text.contains("\n"))
 			throw new IllegalArgumentException("Cannot get width of text containing newline");
@@ -175,7 +175,7 @@ public final class ChatMenuAPI
 	 *
 	 * @param plugin the plugin to initialize everything with, including listeners and scheduled tasks
 	 */
-	public static void init(@Nonnull Plugin plugin)
+	public static void init(@NotNull Plugin plugin)
 	{
 		if(ChatMenuAPI.plugin != null)
 			return;

--- a/src/main/java/me/tom/sparse/spigot/chat/menu/element/BooleanElement.java
+++ b/src/main/java/me/tom/sparse/spigot/chat/menu/element/BooleanElement.java
@@ -9,8 +9,8 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -20,12 +20,12 @@ import java.util.List;
  */
 public class BooleanElement extends Element
 {
-	@Nonnull
+	@NotNull
 	public final State<Boolean> value;
 
-	@Nonnull
+	@NotNull
 	protected ChatColor trueColor  = ChatColor.GREEN;
-	@Nonnull
+	@NotNull
 	protected ChatColor falseColor = ChatColor.RED;
 	
 	protected boolean showText = false;
@@ -48,7 +48,7 @@ public class BooleanElement extends Element
 	 *
 	 * @return this
 	 */
-	@Nonnull
+	@NotNull
 	public BooleanElement showText()
 	{
 		setShowText(true);
@@ -68,8 +68,8 @@ public class BooleanElement extends Element
 	 * @param falseColor The color the symbol should be if the value is {@code false}
 	 * @return this
 	 */
-	@Nonnull
-	public BooleanElement colors(@Nonnull ChatColor trueColor, @Nonnull ChatColor falseColor)
+	@NotNull
+	public BooleanElement colors(@NotNull ChatColor trueColor, @NotNull ChatColor falseColor)
 	{
 		setTrueColor(trueColor);
 		setFalseColor(falseColor);
@@ -79,7 +79,7 @@ public class BooleanElement extends Element
 	/**
 	 * @return the color the text will be if the value is {@code false}
 	 */
-	@Nonnull
+	@NotNull
 	public ChatColor getFalseColor()
 	{
 		return falseColor;
@@ -96,7 +96,7 @@ public class BooleanElement extends Element
 	/**
 	 * @return the color the text will be if the value is {@code true}
 	 */
-	@Nonnull
+	@NotNull
 	public ChatColor getTrueColor()
 	{
 		return trueColor;
@@ -120,8 +120,8 @@ public class BooleanElement extends Element
 		return 1;
 	}
 
-	@Nonnull
-	public List<Text> render(@Nonnull IElementContainer context)
+	@NotNull
+	public List<Text> render(@NotNull IElementContainer context)
 	{
 		String baseCommand = context.getCommand(this);
 		
@@ -138,7 +138,7 @@ public class BooleanElement extends Element
 		return Collections.singletonList(new Text(components));
 	}
 	
-	public void edit(@Nonnull IElementContainer container, @Nonnull String[] args)
+	public void edit(@NotNull IElementContainer container, @NotNull String[] args)
 	{
 		value.setCurrent(Boolean.parseBoolean(args[0]));
 	}
@@ -159,7 +159,7 @@ public class BooleanElement extends Element
 		this.value.setCurrent(value);
 	}
 
-	@Nonnull
+	@NotNull
 	public List<State<?>> getStates()
 	{
 		return Collections.singletonList(value);

--- a/src/main/java/me/tom/sparse/spigot/chat/menu/element/ButtonElement.java
+++ b/src/main/java/me/tom/sparse/spigot/chat/menu/element/ButtonElement.java
@@ -9,8 +9,8 @@ import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.entity.Player;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
@@ -21,7 +21,7 @@ import java.util.function.Function;
  */
 public class ButtonElement extends Element
 {
-	public static ButtonElement createCloseButton(int x, int y, @Nonnull String text, @Nonnull ChatMenu menu)
+	public static ButtonElement createCloseButton(int x, int y, @NotNull String text, @NotNull ChatMenu menu)
 	{
 		return new ButtonElement(x, y, text, (p) -> {
 			menu.close(p);
@@ -29,7 +29,7 @@ public class ButtonElement extends Element
 		});
 	}
 
-	@Nonnull
+	@NotNull
 	protected String                    text;
 	@Nullable
 	protected Function<Player, Boolean> callback;
@@ -41,7 +41,7 @@ public class ButtonElement extends Element
 	 * @param y    the y coordinate
 	 * @param text the text
 	 */
-	public ButtonElement(int x, int y, @Nonnull String text)
+	public ButtonElement(int x, int y, @NotNull String text)
 	{
 		this(x, y, text, (Function<Player, Boolean>) null);
 	}
@@ -54,7 +54,7 @@ public class ButtonElement extends Element
 	 * @param text     the text
 	 * @param callback the callback to be called when the button is clicked.
 	 */
-	public ButtonElement(int x, int y, @Nonnull String text, @Nullable Consumer<Player> callback)
+	public ButtonElement(int x, int y, @NotNull String text, @Nullable Consumer<Player> callback)
 	{
 		this(x, y, text, player -> {
 			if(callback != null)
@@ -71,7 +71,7 @@ public class ButtonElement extends Element
 	 * @param text     the text
 	 * @param callback the callback to be called when the button is clicked. Should return {@code true} to automatically resend the menu.
 	 */
-	public ButtonElement(int x, int y, @Nonnull String text, @Nullable Function<Player, Boolean> callback)
+	public ButtonElement(int x, int y, @NotNull String text, @Nullable Function<Player, Boolean> callback)
 	{
 		super(x, y);
 		if(text.contains("\n"))
@@ -83,7 +83,7 @@ public class ButtonElement extends Element
 	/**
 	 * @return the text this button displays
 	 */
-	@Nonnull
+	@NotNull
 	public String getText()
 	{
 		return text;
@@ -93,7 +93,7 @@ public class ButtonElement extends Element
 	 * @param text the new text this button should display
 	 * @throws IllegalArgumentException if text contains a newline.
 	 */
-	public void setText(@Nonnull String text)
+	public void setText(@NotNull String text)
 	{
 		if(text.contains("\n"))
 			throw new IllegalArgumentException("Button text cannot contain newline");
@@ -115,8 +115,8 @@ public class ButtonElement extends Element
 		return true;
 	}
 
-	@Nonnull
-	public List<Text> render(@Nonnull IElementContainer context)
+	@NotNull
+	public List<Text> render(@NotNull IElementContainer context)
 	{
 		String baseCommand = context.getCommand(this);
 		
@@ -128,13 +128,13 @@ public class ButtonElement extends Element
 		return Collections.singletonList(new Text(components));
 	}
 	
-	public boolean onClick(@Nonnull IElementContainer container, @Nonnull Player player)
+	public boolean onClick(@NotNull IElementContainer container, @NotNull Player player)
 	{
 		super.onClick(container, player);
 		return callback == null ? false : callback.apply(player);
 	}
 	
-	public void edit(@Nonnull IElementContainer container, @Nonnull String[] args)
+	public void edit(@NotNull IElementContainer container, @NotNull String[] args)
 	{
 	}
 }

--- a/src/main/java/me/tom/sparse/spigot/chat/menu/element/Element.java
+++ b/src/main/java/me/tom/sparse/spigot/chat/menu/element/Element.java
@@ -6,8 +6,8 @@ import me.tom.sparse.spigot.chat.util.Text;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -81,7 +81,7 @@ public abstract class Element
 	 *
 	 * @param clickSound the new sound
 	 */
-	public void setClickSound(@Nonnull Sound clickSound)
+	public void setClickSound(@NotNull Sound clickSound)
 	{
 		this.clickSound = clickSound;
 	}
@@ -180,7 +180,7 @@ public abstract class Element
 	 * @param other the element to detect collision with
 	 * @return true of the elements overlap
 	 */
-	public final boolean overlaps(@Nonnull Element other)
+	public final boolean overlaps(@NotNull Element other)
 	{
 		if(other == this)
 			return false;
@@ -225,7 +225,7 @@ public abstract class Element
 	 * @param player the player that clicked this element
 	 * @return true if the menu should rebuild and resend
 	 */
-	public boolean onClick(@Nonnull IElementContainer container, @Nonnull Player player)
+	public boolean onClick(@NotNull IElementContainer container, @NotNull Player player)
 	{
 		if(clickSound != null)
 			player.playSound(player.getEyeLocation(), clickSound, clickVolume, clickPitch);
@@ -237,12 +237,12 @@ public abstract class Element
 	 *  @param container the container this element is being edited on
 	 * @param args the data to be parsed
 	 */
-	public abstract void edit(@Nonnull IElementContainer container, @Nonnull String[] args);
+	public abstract void edit(@NotNull IElementContainer container, @NotNull String[] args);
 	
 	/**
 	 * @return an unmodifiable {@link java.util.Collection} of all the states in this element.
 	 */
-	@Nonnull
+	@NotNull
 	public Collection<State<?>> getStates()
 	{
 		return Collections.emptyList();

--- a/src/main/java/me/tom/sparse/spigot/chat/menu/element/GroupElement.java
+++ b/src/main/java/me/tom/sparse/spigot/chat/menu/element/GroupElement.java
@@ -4,14 +4,14 @@ import me.tom.sparse.spigot.chat.menu.IElementContainer;
 import me.tom.sparse.spigot.chat.util.Text;
 import org.bukkit.entity.Player;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.*;
 
 public class GroupElement extends Element implements IElementContainer
 {
-	@Nonnull
+	@NotNull
 	protected final IElementContainer parent;
-	@Nonnull
+	@NotNull
 	protected       List<Element>     elements;
 	
 	/**
@@ -21,7 +21,7 @@ public class GroupElement extends Element implements IElementContainer
 	 * @param x the x coordinate to put this element at
 	 * @param y the y coordinate to put this element at
 	 */
-	public GroupElement(@Nonnull IElementContainer parent, int x, int y)
+	public GroupElement(@NotNull IElementContainer parent, int x, int y)
 	{
 		super(x, y);
 		this.parent = parent;
@@ -34,7 +34,7 @@ public class GroupElement extends Element implements IElementContainer
 	 * @param <T> the type of element to add
 	 * @return the element that was added
 	 */
-	public <T extends Element> T add(@Nonnull T element)
+	public <T extends Element> T add(@NotNull T element)
 	{
 		Objects.requireNonNull(element);
 		elements.add(element);
@@ -48,7 +48,7 @@ public class GroupElement extends Element implements IElementContainer
 	 * @param element the element to remove
 	 * @return true if the element was removed
 	 */
-	public boolean remove(@Nonnull Element element)
+	public boolean remove(@NotNull Element element)
 	{
 		return elements.remove(element);
 	}
@@ -56,7 +56,7 @@ public class GroupElement extends Element implements IElementContainer
 	/**
 	 * @return an unmodifiable list of all the elements in this group.
 	 */
-	@Nonnull
+	@NotNull
 	public List<Element> getElements()
 	{
 		return Collections.unmodifiableList(elements);
@@ -66,8 +66,8 @@ public class GroupElement extends Element implements IElementContainer
 	 * @param element the element to interact with
 	 * @return the command used to interact with this element
 	 */
-	@Nonnull
-	public String getCommand(@Nonnull Element element)
+	@NotNull
+	public String getCommand(@NotNull Element element)
 	{
 		int index = elements.indexOf(element);
 		if(index == -1)
@@ -89,8 +89,8 @@ public class GroupElement extends Element implements IElementContainer
 		return furthest.getBottom();
 	}
 
-	@Nonnull
-	public List<Text> render(@Nonnull IElementContainer context)
+	@NotNull
+	public List<Text> render(@NotNull IElementContainer context)
 	{
 		if(context != parent)
 			throw new IllegalStateException("Attempted to render GroupElement with non-parent context");
@@ -124,7 +124,7 @@ public class GroupElement extends Element implements IElementContainer
 		return lines;
 	}
 
-	public void edit(@Nonnull IElementContainer container, @Nonnull String[] args)
+	public void edit(@NotNull IElementContainer container, @NotNull String[] args)
 	{
 		int index = Integer.parseInt(args[0]);
 		String[] newArgs = new String[args.length - 1];
@@ -132,7 +132,7 @@ public class GroupElement extends Element implements IElementContainer
 		elements.get(index).edit(container, newArgs);
 	}
 	
-	public void openFor(@Nonnull Player player)
+	public void openFor(@NotNull Player player)
 	{
 		parent.openFor(player);
 	}

--- a/src/main/java/me/tom/sparse/spigot/chat/menu/element/HorizontalRuleElement.java
+++ b/src/main/java/me/tom/sparse/spigot/chat/menu/element/HorizontalRuleElement.java
@@ -5,7 +5,7 @@ import me.tom.sparse.spigot.chat.menu.IElementContainer;
 import me.tom.sparse.spigot.chat.util.Text;
 import me.tom.sparse.spigot.chat.util.TextUtil;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Collections;
 import java.util.List;
 
@@ -53,7 +53,7 @@ public class HorizontalRuleElement extends Element
 		return Collections.singletonList(new Text(text));
 	}
 	
-	public void edit(@Nonnull IElementContainer container, @Nonnull String[] args)
+	public void edit(@NotNull IElementContainer container, @NotNull String[] args)
 	{
 	
 	}

--- a/src/main/java/me/tom/sparse/spigot/chat/menu/element/ImageElement.java
+++ b/src/main/java/me/tom/sparse/spigot/chat/menu/element/ImageElement.java
@@ -7,7 +7,7 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -95,7 +95,7 @@ public class ImageElement extends Element
 		return result;
 	}
 	
-	public void edit(@Nonnull IElementContainer container, @Nonnull String[] args)
+	public void edit(@NotNull IElementContainer container, @NotNull String[] args)
 	{
 		int index = Integer.parseInt(args[0]);
 		colors[index] = onPixelClick(index / 20, index % 20, colors[index]);

--- a/src/main/java/me/tom/sparse/spigot/chat/menu/element/IncrementalElement.java
+++ b/src/main/java/me/tom/sparse/spigot/chat/menu/element/IncrementalElement.java
@@ -9,7 +9,7 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -19,7 +19,7 @@ import java.util.List;
  */
 public class IncrementalElement extends Element
 {
-	@Nonnull
+	@NotNull
 	public final State<Integer> value;
 	protected int min = Integer.MIN_VALUE, max = Integer.MAX_VALUE;
 	
@@ -122,8 +122,8 @@ public class IncrementalElement extends Element
 		return true;
 	}
 
-	@Nonnull
-	public List<Text> render(@Nonnull IElementContainer context)
+	@NotNull
+	public List<Text> render(@NotNull IElementContainer context)
 	{
 		String baseCommand = context.getCommand(this);
 		
@@ -158,12 +158,12 @@ public class IncrementalElement extends Element
 		return Collections.singletonList(new Text(components));
 	}
 	
-	public void edit(@Nonnull IElementContainer container, @Nonnull String[] args)
+	public void edit(@NotNull IElementContainer container, @NotNull String[] args)
 	{
 		value.setCurrent(Integer.parseInt(args[0]));
 	}
 	
-	@Nonnull
+	@NotNull
 	public List<State<?>> getStates()
 	{
 		return Collections.singletonList(value);

--- a/src/main/java/me/tom/sparse/spigot/chat/menu/element/InputElement.java
+++ b/src/main/java/me/tom/sparse/spigot/chat/menu/element/InputElement.java
@@ -9,14 +9,14 @@ import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.ClickEvent;
 import org.bukkit.entity.Player;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.Collections;
 import java.util.List;
 
 public class InputElement extends Element
 {
-	@Nonnull
+	@NotNull
 	public final State<String> value;
 	
 	protected int     width;
@@ -30,7 +30,7 @@ public class InputElement extends Element
 	 * @param width the max width of the text
 	 * @param value the starting text
 	 */
-	public InputElement(int x, int y, int width, @Nonnull String value)
+	public InputElement(int x, int y, int width, @NotNull String value)
 	{
 		super(x, y);
 		this.width = width;
@@ -51,7 +51,7 @@ public class InputElement extends Element
 	 *
 	 * @param value the new value
 	 */
-	public void setValue(@Nonnull String value)
+	public void setValue(@NotNull String value)
 	{
 //		if(ChatMenuAPI.getWidth(text) > width)
 //			throw new IllegalArgumentException("The provided text is too wide to fit!");
@@ -68,8 +68,8 @@ public class InputElement extends Element
 		return 1;
 	}
 
-	@Nonnull
-	public List<Text> render(@Nonnull IElementContainer context)
+	@NotNull
+	public List<Text> render(@NotNull IElementContainer context)
 	{
 		ClickEvent click = new ClickEvent(ClickEvent.Action.RUN_COMMAND, context.getCommand(this));
 		
@@ -90,7 +90,7 @@ public class InputElement extends Element
 		return Collections.singletonList(text);
 	}
 	
-	public boolean onClick(@Nonnull IElementContainer container, @Nonnull Player player)
+	public boolean onClick(@NotNull IElementContainer container, @NotNull Player player)
 	{
 		super.onClick(container, player);
 		container.getElements().stream().filter(it -> it instanceof InputElement && it != this).map(it -> (InputElement) it).forEach(it -> it.editing = false);
@@ -112,12 +112,12 @@ public class InputElement extends Element
 		return true;
 	}
 	
-	public void edit(@Nonnull IElementContainer container, @Nonnull String[] args)
+	public void edit(@NotNull IElementContainer container, @NotNull String[] args)
 	{
 	
 	}
 	
-	@Nonnull
+	@NotNull
 	public List<State<?>> getStates()
 	{
 		return Collections.singletonList(value);

--- a/src/main/java/me/tom/sparse/spigot/chat/menu/element/LinkButtonElement.java
+++ b/src/main/java/me/tom/sparse/spigot/chat/menu/element/LinkButtonElement.java
@@ -7,7 +7,7 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.Collections;
 import java.util.List;
 
@@ -16,9 +16,9 @@ import java.util.List;
  */
 public class LinkButtonElement extends Element
 {
-	@Nonnull
+	@NotNull
 	protected String text;
-	@Nonnull
+	@NotNull
 	protected String link;
 	
 	/**
@@ -30,7 +30,7 @@ public class LinkButtonElement extends Element
 	 * @param link the link
 	 * @throws IllegalArgumentException if text contains newlines
 	 */
-	public LinkButtonElement(int x, int y, @Nonnull String text, @Nonnull String link)
+	public LinkButtonElement(int x, int y, @NotNull String text, @NotNull String link)
 	{
 		super(x, y);
 		if(text.contains("\n"))
@@ -42,7 +42,7 @@ public class LinkButtonElement extends Element
 	/**
 	 * @return the text that displays for this button
 	 */
-	@Nonnull
+	@NotNull
 	public String getText()
 	{
 		return text;
@@ -51,7 +51,7 @@ public class LinkButtonElement extends Element
 	/**
 	 * @param text the new text to display
 	 */
-	public void setText(@Nonnull String text)
+	public void setText(@NotNull String text)
 	{
 		if(text.contains("\n"))
 			throw new IllegalArgumentException("Button text cannot contain newline");
@@ -61,7 +61,7 @@ public class LinkButtonElement extends Element
 	/**
 	 * @return the link
 	 */
-	@Nonnull
+	@NotNull
 	public String getLink()
 	{
 		return link;
@@ -70,7 +70,7 @@ public class LinkButtonElement extends Element
 	/**
 	 * @param link the new link
 	 */
-	public void setLink(@Nonnull String link)
+	public void setLink(@NotNull String link)
 	{
 		this.link = link;
 	}
@@ -95,7 +95,7 @@ public class LinkButtonElement extends Element
 		return Collections.singletonList(new Text(components));
 	}
 	
-	public void edit(@Nonnull IElementContainer container, @Nonnull String[] args)
+	public void edit(@NotNull IElementContainer container, @NotNull String[] args)
 	{
 	}
 }

--- a/src/main/java/me/tom/sparse/spigot/chat/menu/element/NumberSliderElement.java
+++ b/src/main/java/me/tom/sparse/spigot/chat/menu/element/NumberSliderElement.java
@@ -11,8 +11,8 @@ import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.entity.Player;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -22,16 +22,16 @@ public class NumberSliderElement extends Element
 	public static final int MIN_PRECISION = 0;
 	public static final int MAX_PRECISION = 7;
 
-	@Nonnull
+	@NotNull
 	public final State<Integer> value;
 	protected    int            length;
 
-	@Nonnull
+	@NotNull
 	protected ChatColor fullColor  = ChatColor.GREEN;
-	@Nonnull
+	@NotNull
 	protected ChatColor emptyColor = ChatColor.RED;
 
-	@Nonnull
+	@NotNull
 	protected NumberFormat numberFormat = NumberFormat.PERCENTAGE;
 	
 	protected int precision = 6;
@@ -80,8 +80,8 @@ public class NumberSliderElement extends Element
 	 * @param emptyColor the color for all of the empty bars
 	 * @return this
 	 */
-	@Nonnull
-	public NumberSliderElement colors(@Nonnull ChatColor fullColor, @Nonnull ChatColor emptyColor)
+	@NotNull
+	public NumberSliderElement colors(@NotNull ChatColor fullColor, @NotNull ChatColor emptyColor)
 	{
 		setFullColor(fullColor);
 		setEmptyColor(emptyColor);
@@ -113,7 +113,7 @@ public class NumberSliderElement extends Element
 	/**
 	 * @return the current number format
 	 */
-	@Nonnull
+	@NotNull
 	public NumberFormat getNumberFormat()
 	{
 		return numberFormat;
@@ -165,7 +165,7 @@ public class NumberSliderElement extends Element
 	/**
 	 * @return the color for all of the empty bars
 	 */
-	@Nonnull
+	@NotNull
 	public ChatColor getEmptyColor()
 	{
 		return emptyColor;
@@ -182,7 +182,7 @@ public class NumberSliderElement extends Element
 	/**
 	 * @return the color for all of the full bars
 	 */
-	@Nonnull
+	@NotNull
 	public ChatColor getFullColor()
 	{
 		return fullColor;
@@ -229,7 +229,7 @@ public class NumberSliderElement extends Element
 	 * @param width the width to attempt to match
 	 * @return this
 	 */
-	@Nonnull
+	@NotNull
 	public NumberSliderElement width(int width)
 	{
 		setWidth(width);
@@ -303,19 +303,19 @@ public class NumberSliderElement extends Element
 		return true;
 	}
 	
-	public boolean onClick(@Nonnull IElementContainer container, @Nonnull Player player)
+	public boolean onClick(@NotNull IElementContainer container, @NotNull Player player)
 	{
 		return isEnabled() && super.onClick(container, player);
 	}
 	
-	public void edit(@Nonnull IElementContainer container, @Nonnull String[] args)
+	public void edit(@NotNull IElementContainer container, @NotNull String[] args)
 	{
 		if(!isEnabled())
 			return;
 		value.setCurrent(Integer.parseInt(args[0]));
 	}
 	
-	@Nonnull
+	@NotNull
 	public List<State<?>> getStates()
 	{
 		return Collections.singletonList(value);

--- a/src/main/java/me/tom/sparse/spigot/chat/menu/element/TextElement.java
+++ b/src/main/java/me/tom/sparse/spigot/chat/menu/element/TextElement.java
@@ -4,8 +4,8 @@ import me.tom.sparse.spigot.chat.menu.ChatMenuAPI;
 import me.tom.sparse.spigot.chat.menu.IElementContainer;
 import me.tom.sparse.spigot.chat.util.Text;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -16,11 +16,11 @@ public class TextElement extends Element
 {
 	protected static final int BORDER_WIDTH = ChatMenuAPI.getWidth("|  |");
 
-	@Nonnull
+	@NotNull
 	protected String[] lines;
 	protected int      width;
 
-	@Nonnull
+	@NotNull
 	protected TextAlignment alignment = TextAlignment.LEFT;
 	protected boolean border;
 	
@@ -31,7 +31,7 @@ public class TextElement extends Element
 	 * @param x    the x coordinate
 	 * @param y    the y coordinate
 	 */
-	public TextElement(@Nonnull String text, int x, int y)
+	public TextElement(@NotNull String text, int x, int y)
 	{
 		super(x, y);
 		
@@ -57,7 +57,7 @@ public class TextElement extends Element
 	 * @param y    the y coordinate
 	 * @param text the lines of text. Lines may not contain {@code \n}
 	 */
-	public TextElement(int x, int y, @Nonnull String... text)
+	public TextElement(int x, int y, @NotNull String... text)
 	{
 		super(x, y);
 		
@@ -77,7 +77,7 @@ public class TextElement extends Element
 		setLines(text.split("\n"));
 	}
 	
-	public void setLines(@Nonnull String... lines)
+	public void setLines(@NotNull String... lines)
 	{
 		int newWidth = 0;
 		for(String line : lines)
@@ -97,7 +97,7 @@ public class TextElement extends Element
 	 *
 	 * @return this
 	 */
-	@Nonnull
+	@NotNull
 	public TextElement border()
 	{
 		this.border = true;
@@ -126,8 +126,8 @@ public class TextElement extends Element
 	 * @param alignment the new text alignment
 	 * @return this
 	 */
-	@Nonnull
-	public TextElement align(@Nonnull TextAlignment alignment)
+	@NotNull
+	public TextElement align(@NotNull TextAlignment alignment)
 	{
 		setAlignment(alignment);
 		return this;
@@ -136,7 +136,7 @@ public class TextElement extends Element
 	/**
 	 * @return the current text alignment
 	 */
-	@Nonnull
+	@NotNull
 	public TextAlignment getAlignment()
 	{
 		return alignment;
@@ -249,7 +249,7 @@ public class TextElement extends Element
 		return result;
 	}
 	
-	public void edit(@Nonnull IElementContainer container, @Nonnull String[] args)
+	public void edit(@NotNull IElementContainer container, @NotNull String[] args)
 	{
 	
 	}

--- a/src/main/java/me/tom/sparse/spigot/chat/menu/element/VerticalSelectorElement.java
+++ b/src/main/java/me/tom/sparse/spigot/chat/menu/element/VerticalSelectorElement.java
@@ -9,8 +9,8 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -22,12 +22,12 @@ public class VerticalSelectorElement extends Element
 {
 	protected static final int SELECTED_PREFIX_WIDTH = ChatMenuAPI.getWidth("> ");
 
-	@Nonnull
+	@NotNull
 	protected String[] options;
 	protected int      width;
 	
 	//	protected int selectedIndex;
-	@Nonnull
+	@NotNull
 	public final State<Integer> value;
 	
 	@Nullable
@@ -41,7 +41,7 @@ public class VerticalSelectorElement extends Element
 	 * @param defaultSelected the selected option index
 	 * @param options         the list of options. Options may not contain {@code \n}
 	 */
-	public VerticalSelectorElement(int x, int y, int defaultSelected, @Nonnull String... options)
+	public VerticalSelectorElement(int x, int y, int defaultSelected, @NotNull String... options)
 	{
 		super(x, y);
 		for(String option : options)
@@ -149,12 +149,12 @@ public class VerticalSelectorElement extends Element
 		return result;
 	}
 	
-	public void edit(@Nonnull IElementContainer container, @Nonnull String[] args)
+	public void edit(@NotNull IElementContainer container, @NotNull String[] args)
 	{
 		value.setCurrent(Integer.parseInt(args[0]));
 	}
 	
-	@Nonnull
+	@NotNull
 	public List<State<?>> getStates()
 	{
 		return Collections.singletonList(value);

--- a/src/main/java/me/tom/sparse/spigot/chat/util/State.java
+++ b/src/main/java/me/tom/sparse/spigot/chat/util/State.java
@@ -1,7 +1,7 @@
 package me.tom.sparse.spigot.chat.util;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -11,7 +11,7 @@ public class State<V>
 {
 	private Consumer<State<V>> changeCallback;
 	
-	@Nonnull
+	@NotNull
 	private Function<V, V> valueFilter;
 
 	@Nullable
@@ -103,7 +103,7 @@ public class State<V>
 	 *
 	 * @param changeCallback the new change callback.
 	 */
-	public void setChangeCallback(@Nonnull Consumer<State<V>> changeCallback)
+	public void setChangeCallback(@NotNull Consumer<State<V>> changeCallback)
 	{
 		this.changeCallback = changeCallback;
 	}

--- a/src/main/java/me/tom/sparse/spigot/chat/util/Text.java
+++ b/src/main/java/me/tom/sparse/spigot/chat/util/Text.java
@@ -4,7 +4,7 @@ import me.tom.sparse.spigot.chat.menu.ChatMenuAPI;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 import java.util.*;
 
 /**
@@ -12,7 +12,7 @@ import java.util.*;
  */
 public class Text
 {
-	@Nonnull
+	@NotNull
 	protected List<BaseComponent> components = new ArrayList<>();
 	protected int                 width      = 0;
 	
@@ -30,7 +30,7 @@ public class Text
 	 *
 	 * @param text the starting text
 	 */
-	public Text(@Nonnull String text)
+	public Text(@NotNull String text)
 	{
 		if(text.contains("\n"))
 			throw new IllegalArgumentException("Text cannot have newline characters");
@@ -44,7 +44,7 @@ public class Text
 	 *
 	 * @param components the starting components
 	 */
-	public Text(@Nonnull BaseComponent... components)
+	public Text(@NotNull BaseComponent... components)
 	{
 		this(Arrays.asList(components));
 	}
@@ -54,7 +54,7 @@ public class Text
 	 *
 	 * @param components the starting components
 	 */
-	public Text(@Nonnull Collection<BaseComponent> components)
+	public Text(@NotNull Collection<BaseComponent> components)
 	{
 		this.components.addAll(components);
 		if(toLegacyText().contains("\n"))
@@ -75,7 +75,7 @@ public class Text
 	 *
 	 * @param other the {@code Text} to append
 	 */
-	public void append(@Nonnull Text other)
+	public void append(@NotNull Text other)
 	{
 		components.addAll(other.components);
 		width += other.width;
@@ -86,7 +86,7 @@ public class Text
 	 *
 	 * @param text the text to append
 	 */
-	public void append(@Nonnull String text)
+	public void append(@NotNull String text)
 	{
 		if(text.contains("\n"))
 			throw new IllegalArgumentException("Text cannot have newline characters");
@@ -99,7 +99,7 @@ public class Text
 	 *
 	 * @param components the components to append
 	 */
-	public void append(@Nonnull BaseComponent... components)
+	public void append(@NotNull BaseComponent... components)
 	{
 		Collections.addAll(this.components, components);
 		calculateWidth();
@@ -150,7 +150,7 @@ public class Text
 	/**
 	 * @return the components of this {@code Text} object converted to legacy.
 	 */
-	@Nonnull
+	@NotNull
 	public String toLegacyText()
 	{
 		return TextComponent.toLegacyText(components.toArray(new BaseComponent[components.size()]));
@@ -161,7 +161,7 @@ public class Text
 	 *
 	 * @return the backing list of the components in this {@code Text} object.
 	 */
-	@Nonnull
+	@NotNull
 	public List<BaseComponent> getComponents()
 	{
 		return components;


### PR DESCRIPTION
 - added the `target` folder to the `.gitignore`
 - made the `pom.xml` prettier and fixed some issues with it
 - changed the version to 1.12.2 from 1.12
 - jsr305 was included for no reason, internally the unsupported javax annotations were used. Changed all of them to the JetBrains annotations